### PR TITLE
update apt repo for apt module v2.0 and later

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,8 +18,10 @@ class ossec::repo (
             location    => 'http://ossec.wazuh.com/repos/apt/ubuntu',
             release     => $::lsbdistcodename,
             repos       => 'main',
-            include_src => false,
-            include_deb => true,
+            include     => {
+              'src'     => false,
+              'deb'     => true,
+            },
           }
           ~>
           exec { 'update-apt-wazuh-repo':


### PR DESCRIPTION
This is a breaking change for anyone still using the puppetlabs-apt module v1.8 or earlier, but is required for v2.0 and later.